### PR TITLE
respect proxy environment variables

### DIFF
--- a/lib/Travel/Status/DE/VRR.pm
+++ b/lib/Travel/Status/DE/VRR.pm
@@ -97,6 +97,8 @@ sub new {
 
 	bless( $self, $class );
 
+	$ua->env_proxy;
+
 	my $response
 	  = $ua->post( 'http://efa.vrr.de/vrr/XSLT_DM_REQUEST', $self->{post} );
 


### PR DESCRIPTION
(shameless copy of https://github.com/derf/Travel-Routing-DE-VRR/pull/4)

This little patch makes Travel::Status::DE::VRR respect the HTTP_PROXY
environment variable, which is the standard environment variable for proxy
configuration and is also used by many other applications.
