### PR TITLE
Add RVV service (Regensburger Verkehrsverbund)

### DIFF
--- a/lib/Travel/Status/DE/EFA/Services.pm.PL
+++ b/lib/Travel/Status/DE/EFA/Services.pm.PL
@@ -60,6 +60,10 @@ my %efa_instance = (
 		name => 'Nahverkehr Westfalen-Lippe',
 	},
 	Rolph => { load_instance('de/rolph') },
+	RVV => {
+		url  => 'https://efa.rvv.de/efa',
+		name => 'Regensburger Verkehrsverbund',
+	},
 	VAG => {
 		url  => 'https://efa.vagfr.de/vagfr3',
 		name => 'Freiburger Verkehrs AG',

--- a/scripts/check-efa-urls
+++ b/scripts/check-efa-urls
@@ -8,6 +8,7 @@ KVV Karlsruhe Hbf
 LinzAG Linz/Donau Hbf
 MVV München Hackerbrücke
 NVBW Stuttgart Hbf (A.-Klett-Pl.)
+RVV Regensburg Hbf
 VAG Schallstadt Bf
 VGN Nürnberg Hbf
 VMV Schwerin Hbf


### PR DESCRIPTION
EFA URL obtained from https://efa.rvv.de/rvv/trip,  
tested using https://finalrewind.org/interblag/entry/efa-json-api/,  
**not** tested in Travel-Status-DE-VRR itself though.